### PR TITLE
Add SEO meta tags, Open Graph image, favicon, and structured data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,10 @@ RUN mix compile
 
 COPY assets assets
 
+# Generate branded PNG assets (og-image.png, apple-touch-icon.png) from source
+# Uses only Node built-ins — no extra packages needed.
+RUN node assets/gen_og_image.mjs
+
 # compile assets
 RUN mix assets.deploy
 

--- a/lib/apus_landing_web.ex
+++ b/lib/apus_landing_web.ex
@@ -17,7 +17,7 @@ defmodule ApusLandingWeb do
   those modules here.
   """
 
-  def static_paths, do: ~w(assets fonts images favicon.ico robots.txt install.sh llms.txt)
+  def static_paths, do: ~w(assets fonts images favicon.ico apple-touch-icon.png robots.txt install.sh llms.txt)
 
   def router do
     quote do

--- a/lib/apus_landing_web/components/layouts/root.html.heex
+++ b/lib/apus_landing_web/components/layouts/root.html.heex
@@ -8,6 +8,37 @@
       name="description"
       content="Runtime visibility for coding agents. Give your AI eyes on your iOS app."
     />
+    <link rel="canonical" href="https://getapus.dev/" />
+
+    <%!-- Favicon --%>
+    <link rel="icon" href="/images/logo.svg" type="image/svg+xml" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+
+    <%!-- Open Graph --%>
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Apus" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:url" content="https://getapus.dev/" />
+    <meta property="og:title" content="Apus — Runtime visibility for coding agents" />
+    <meta
+      property="og:description"
+      content="Runtime visibility for coding agents. Give your AI eyes on your iOS app."
+    />
+    <meta property="og:image" content="https://getapus.dev/images/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:type" content="image/png" />
+
+    <%!-- Twitter Card --%>
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Apus — Runtime visibility for coding agents" />
+    <meta
+      name="twitter:description"
+      content="Runtime visibility for coding agents. Give your AI eyes on your iOS app."
+    />
+    <meta name="twitter:image" content="https://getapus.dev/images/og-image.png" />
+
     <.live_title default="Apus" suffix=" — Runtime visibility for coding agents">
       {assigns[:page_title]}
     </.live_title>
@@ -20,6 +51,24 @@
         to_url={fn p -> static_url(@conn, p) end}
       />
     <% end %>
+    <%!-- JSON-LD Structured Data --%>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Apus",
+        "url": "https://getapus.dev/",
+        "description": "Runtime visibility for coding agents. Give your AI eyes on your iOS app.",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "macOS, iOS",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
+    </script>
+
     <script type="text/javascript">
       (function(c,l,a,r,i,t,y){
           c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};

--- a/lib/apus_landing_web/live/landing_live.ex
+++ b/lib/apus_landing_web/live/landing_live.ex
@@ -3,10 +3,7 @@ defmodule ApusLandingWeb.LandingLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok,
-     assign(socket,
-       page_title: "Runtime visibility for coding agents"
-     )}
+    {:ok, socket}
   end
 
   @impl true

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "gen-assets": "node assets/gen_og_image.mjs"
+  },
   "dependencies": {
     "@vueuse/core": "^13.7.0",
     "live_vue": "file:./deps/live_vue",


### PR DESCRIPTION
## Summary
- Open Graph tags (title, description, image 1200x630, url, type)
- Twitter Card tags (summary_large_image)
- Canonical URL
- Favicon (SVG + ico + apple-touch-icon)
- JSON-LD structured data (SoftwareApplication)
- Build-time OG image generator in Dockerfile

Closes #6

🤖 Generated by Symphony + Claude Code agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced social media sharing with improved preview metadata when links are shared
  * Added apple-touch icon support for iOS home screen compatibility
  * Improved search engine visibility with structured data markup

* **Chores**
  * Updated build process to generate and deploy branded app assets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->